### PR TITLE
Fix ECP5 SPI protocol and split V4L2 lock from DMA lock

### DIFF
--- a/sc0710-cards.c
+++ b/sc0710-cards.c
@@ -243,13 +243,14 @@ static u32 ecp5_read_idcode(struct sc0710_dev *dev)
 
 static int ecp5_check_busy(struct sc0710_dev *dev, int timeout_ms)
 {
-	u8 tx[4] = { ECP5_LSC_CHECK_BUSY, 0, 0, 0 };
+	/* 4 command bytes + 1 dummy byte to clock out response */
+	u8 tx[5] = { ECP5_LSC_CHECK_BUSY, 0, 0, 0, 0 };
 	u8 rx[1];
 	int i;
 
 	for (i = 0; i < timeout_ms; i++) {
-		ecp5_spi_xfer(dev, tx, 4, rx, 1);
-		if (!rx[0])
+		ecp5_spi_xfer(dev, tx, 5, rx, 1);
+		if (!(rx[0] & 0x80))
 			return 0;
 		msleep(1);
 	}
@@ -275,20 +276,17 @@ static int ecp5_program_bitstream(struct sc0710_dev *dev, const u8 *data, u32 le
 
 	ecp5_spi_reset(dev);
 
-	/* If ECP5 is unresponsive (e.g. after failed programming),
-	 * send REFRESH to reset back to factory firmware.
+	/* Always REFRESH before programming to ensure clean state.
+	 * After a failed programming attempt, the ECP5 can be stuck
+	 * in ISC mode with dirty status bits. REFRESH resets it.
 	 */
-	if (ecp5_read_idcode(dev) == 0xFFFFFFFF) {
-		printk(KERN_WARNING "%s: ECP5 unresponsive, sending REFRESH\n",
-			dev->name);
-		cmd[0] = ECP5_LSC_REFRESH;
-		cmd[1] = 0x00;
-		cmd[2] = 0x00;
-		cmd[3] = 0x00;
-		ecp5_spi_xfer(dev, cmd, 4, NULL, 0);
-		msleep(200);
-		ecp5_spi_reset(dev);
-	}
+	cmd[0] = ECP5_LSC_REFRESH;
+	cmd[1] = 0x00;
+	cmd[2] = 0x00;
+	cmd[3] = 0x00;
+	ecp5_spi_xfer(dev, cmd, 4, NULL, 0);
+	msleep(200);
+	ecp5_spi_reset(dev);
 
 	/* ISC_ENABLE */
 	cmd[0] = ECP5_ISC_ENABLE;
@@ -297,9 +295,11 @@ static int ecp5_program_bitstream(struct sc0710_dev *dev, const u8 *data, u32 le
 	cmd[3] = 0x00;
 	ecp5_spi_xfer(dev, cmd, 4, NULL, 0);
 	msleep(1);
-	ret = ecp5_check_busy(dev, 100);
+	ret = ecp5_check_busy(dev, 1000);
 	if (ret) {
-		printk(KERN_ERR "%s: ECP5 ISC_ENABLE failed\n", dev->name);
+		ecp5_read_status(dev, &status);
+		printk(KERN_ERR "%s: ECP5 ISC_ENABLE failed (status: %08x)\n",
+			dev->name, status);
 		return ret;
 	}
 
@@ -325,6 +325,13 @@ static int ecp5_program_bitstream(struct sc0710_dev *dev, const u8 *data, u32 le
 
 	/* BITSTREAM_BURST — command + data in one CS cycle */
 	ecp5_spi_burst_write(dev, data, len);
+
+	/* Check status register before ISC_DISABLE (flow diagram step 7) */
+	ecp5_read_status(dev, &status);
+	if (status & 0x3802000) {  /* Fail Flag (bit 13) or BSE Error Code (bits 25:23) */
+		printk(KERN_ERR "%s: ECP5 bitstream error (status: %08x)\n",
+			dev->name, status);
+	}
 
 	/* ISC_DISABLE + NOP + STATUS (matching Windows sequence) */
 	cmd[0] = ECP5_ISC_DISABLE;

--- a/sc0710-dma-channel.c
+++ b/sc0710-dma-channel.c
@@ -464,6 +464,7 @@ int sc0710_dma_channel_alloc(struct sc0710_dev *dev, u32 nr, enum sc0710_channel
 
 	memset(ch, 0, sizeof(*ch));
 	mutex_init(&ch->lock);
+	mutex_init(&ch->v4l2_lock);
 
 	/* Multi-client streaming support initialization */
 	atomic_set(&ch->streaming_refcount, 0);

--- a/sc0710-i2c.c
+++ b/sc0710-i2c.c
@@ -786,7 +786,7 @@ int sc0710_4kp_wait_pipeline(struct sc0710_dev *dev)
 	/* MCU TX status for diagnostics */
 	wbuf[0] = 0x10;
 	__sc0710_i2c_writeread(dev, I2C_DEV__ARM_MCU, wbuf, 1, rbuf, 16);
-	printk(KERN_INFO "%s: MCU TX status [13-15]: %02x %02x %02x (0x80=disabled)\n",
+	printk(KERN_INFO "%s: MCU status [13-15]: %02x %02x %02x\n",
 		dev->name, rbuf[3], rbuf[4], rbuf[5]);
 
 	/* Poll A8 — 4KP FPGA pipeline may need time to become active. */

--- a/sc0710-video.c
+++ b/sc0710-video.c
@@ -1064,10 +1064,8 @@ static int sc0710_video_open(struct file *file)
 	list_add_tail(&fh->client->list, &ch->client_list);
 	spin_unlock_irqrestore(&ch->client_list_lock, flags);
 
-	/* Track video users */
-	mutex_lock(&ch->lock);
+	/* Track video users (v4l2_lock already held by framework) */
 	ch->videousers++;
-	mutex_unlock(&ch->lock);
 
 	v4l2_fh_init(&fh->fh, vdev);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
@@ -1109,10 +1107,9 @@ static int sc0710_video_release(struct file *file)
 		fh->client = NULL;
 	}
 
-	mutex_lock(&ch->lock);
+	/* v4l2_lock already held by framework */
 	ch->videousers--;
 	dprintk(2, "%s() videousers=%d\n", __func__, ch->videousers);
-	mutex_unlock(&ch->lock);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
 	v4l2_fh_del(&fh->fh, file);
@@ -1381,7 +1378,7 @@ int sc0710_video_register(struct sc0710_dma_channel *ch)
 	q->mem_ops = &vb2_vmalloc_memops;
 	q->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
 	q->min_queued_buffers = 2;
-	q->lock = &ch->lock;
+	q->lock = &ch->v4l2_lock;
 	q->dev = &dev->pci->dev;
 
 	err = vb2_queue_init(q);
@@ -1401,7 +1398,7 @@ int sc0710_video_register(struct sc0710_dma_channel *ch)
 #endif
 
 	memcpy(&ch->vdev, &sc0710_video_template, sizeof(sc0710_video_template));
-	ch->vdev.lock = &ch->lock;
+	ch->vdev.lock = &ch->v4l2_lock;
 	ch->vdev.release = video_device_release_empty;
 	ch->vdev.vfl_dir = VFL_DIR_RX;
 	ch->vdev.queue = q;

--- a/sc0710.h
+++ b/sc0710.h
@@ -232,6 +232,7 @@ struct sc0710_dma_channel
 	dma_addr_t  pt_dma;  /* Physical address - accessible to the PCIe endpoint */
 
 	struct mutex                 lock;
+	struct mutex                 v4l2_lock; /* Separate lock for V4L2/VB2 serialization */
 	u32                          numDescriptorChains;
 	u32                          buf_size;
 	struct sc0710_dma_descriptor_chain chains[SC0710_MAX_CHANNEL_DESCRIPTOR_CHAINS];


### PR DESCRIPTION
I'd pulled the latest code locally but was still having issues getting things working with my  Elgato 4K Pro (1cfa:0012)

Did some claude-assisted debugging and arrived at these changes:
- Fix ecp5_check_busy to send 5 bytes (4 cmd + 1 dummy) and check bit 7
  for busy flag, matching the Lattice ECP5 sysCONFIG specification
- Always send REFRESH before programming to handle stuck ISC state
- Add status register check (fail flag, BSE error code) after bitstream
  burst per FPGA-TN-02039 flow diagram step 7, before ISC_DISABLE
- Split v4l2_lock from ch->lock to prevent potential deadlock between
  V4L2 framework serialization and DMA hardware state protection
- Remove redundant mutex around videousers (v4l2_lock held by framework)

I certainly don't claim to be a firmware expert. I did go read the FPGA docs to validate that we're not hallucinating here and that these changes seem sane.