### PR TITLE
Fix 5s delay on 4KP DMA start by moving pipeline wait

### DIFF
--- a/sc0710-dma-channels.c
+++ b/sc0710-dma-channels.c
@@ -80,13 +80,6 @@ int sc0710_dma_channels_start(struct sc0710_dev *dev)
 
 	printk("%s()\n", __func__);
 
-	/* Wait for 4KP FPGA pipeline to become active before DMA start */
-	if (dev->board == SC0710_BOARD_ELGATEO_4KP) {
-		mutex_lock(&dev->signalMutex);
-		sc0710_4kp_wait_pipeline(dev);
-		mutex_unlock(&dev->signalMutex);
-	}
-
 	/* Prepare all DMA channels to start */
 	for (i = 0; i < SC0710_MAX_CHANNELS; i++) {
 		ret = sc0710_dma_channel_start_prep(&dev->channel[i]);
@@ -129,22 +122,8 @@ int sc0710_dma_channels_start(struct sc0710_dev *dev)
 	if (dev->board == SC0710_BOARD_ELGATEO_4KP)
 		sc_write(dev, 0, 0xEC, 0x00000001);
 
-	if (dev->board == SC0710_BOARD_ELGATEO_4KP) {
-		int poll;
-		u32 a8;
-		for (poll = 0; poll < 20; poll++) {
-			msleep(100);
-			a8 = sc_read(dev, 0, 0xa8);
-			if (a8 != 0) {
-				printk(KERN_INFO "%s: A8 active after %dms: %08x\n",
-					dev->name, (poll + 1) * 100, a8);
-				break;
-			}
-		}
-		if (a8 == 0)
-			printk(KERN_WARNING "%s: A8 still 0 after 2s — DMA may stall\n",
-				dev->name);
-	}
+	if (dev->board == SC0710_BOARD_ELGATEO_4KP)
+		sc0710_4kp_wait_pipeline(dev);
 
 	/* Start all DMA channels after pipeline is active. */
 	for (i = 0; i < SC0710_MAX_CHANNELS; i++) {

--- a/sc0710-i2c.c
+++ b/sc0710-i2c.c
@@ -789,18 +789,20 @@ int sc0710_4kp_wait_pipeline(struct sc0710_dev *dev)
 	printk(KERN_INFO "%s: MCU status [13-15]: %02x %02x %02x\n",
 		dev->name, rbuf[3], rbuf[4], rbuf[5]);
 
-	/* Poll A8 — 4KP FPGA pipeline may need time to become active. */
-	for (i = 0; i < 10; i++) {
-		msleep(500);
+	/* Poll A8 — 4KP FPGA pipeline may need time to become active
+	 * after D0/EC register writes. Typically activates within 100ms.
+	 */
+	for (i = 0; i < 20; i++) {
+		msleep(100);
 		a8 = sc_read(dev, 0, 0xa8);
 		if (a8 != 0) {
 			printk(KERN_INFO "%s: A8 active after %dms: %08x\n",
-				dev->name, (i + 1) * 500, a8);
+				dev->name, (i + 1) * 100, a8);
 			return 0;
 		}
 	}
 
-	printk(KERN_INFO "%s: A8 still 0 after 5s — 4KP pipeline not active\n", dev->name);
+	printk(KERN_WARNING "%s: A8 still 0 after 2s — DMA may stall\n", dev->name);
 	return 0;
 }
 


### PR DESCRIPTION
## Summary
- Remove the premature `sc0710_4kp_wait_pipeline()` call that polled A8 for 5s **before** the D0/EC register writes that actually activate the pipeline — this could never succeed
- Replace the inline A8 poll loop (after register writes) with a call to `sc0710_4kp_wait_pipeline()`, consolidating the logic in one place
- Reduce poll interval from 500ms to 100ms and total timeout from 5s to 2s, matching observed activation time (~100ms)