### PR TITLE
(#31) Update sc0710-cli.sh to use a portable bash shebang

### DIFF
--- a/scripts/sc0710-cli.sh
+++ b/scripts/sc0710-cli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SC0710 Control Utility - Unified for Atomic and Non-Atomic distros
 # Detects distro type at runtime and branches accordingly.
 


### PR DESCRIPTION
When I was trying to package the existing script for NixOS, running the script threw a "bad interpreter" error because `bash` is in the Nix store instead of the usual location (`/bin/bash`).

However, `/usr/bin/env` does exist and it is able to point to the `bash` in the Nix store.

Parent issue: https://github.com/Nakildias/sc0710/issues/31