### PR TITLE
fix: evaluation warning when building on NixOS 26.05

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ let
         enableParallelBuilding = true;
 
         src = ./.;
-        nativeBuildInputs = [ config.hardware.sc0710.kernel.moduleBuildDependencies ];
+        nativeBuildInputs = config.hardware.sc0710.kernel.moduleBuildDependencies;
 
         makeFlags = [
             "KBUILD_DIR=${config.hardware.sc0710.kernel.dev}/lib/modules/${config.hardware.sc0710.kernel.modDirVersion}/build"


### PR DESCRIPTION
This commit fixes the evaluation warning when building on NixOS 26.05:

```
evaluation warning: Dependency of package 'sc0710-2026.04.16-1
                    -7.0.10' uses a nested list in attribute 'nativeBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
```

This is because `config.hardware.sc0710.kernel.moduleBuildDependencies` is already a list.

Removing the nested list will fixes this warning