### PR TITLE
fix(build): drop MO= so kbuild does not corrupt the kernel's Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,8 @@ $(VERSION_HDR): version
 
 all: $(VERSION_HDR)
 	@mkdir -p "$(MODULE_OUTPUT_DIR)"
-	$(MAKE) -C "$(KBUILD_DIR)" M="$(CURDIR)" MO="$(MODULE_OUTPUT_DIR)" $(KBUILD_CC) modules
-	@# Fallback for kernels < 6.13 where MO= is not supported:
-	@# the .ko ends up at the source root instead of build/.
+	$(MAKE) -C "$(KBUILD_DIR)" M="$(CURDIR)" $(KBUILD_CC) modules
+	@# kbuild builds in place; stage the resulting module into build/.
 	@if [ -f "$(CURDIR)/sc0710.ko" ] && [ ! -f "$(MODULE_OUTPUT_DIR)/sc0710.ko" ]; then \
 		cp "$(CURDIR)/sc0710.ko" "$(MODULE_OUTPUT_DIR)/sc0710.ko"; \
 	fi
@@ -59,7 +58,7 @@ clean:
 	rm -f sc0710.ko sc0710.o sc0710.mod sc0710.mod.c sc0710.mod.o .module-common.o \
 		Module.symvers modules.order .sc0710*.cmd .module-common*.cmd .modules*.cmd
 	rm -rf .tmp_versions
-	$(MAKE) -C "$(KBUILD_DIR)" M="$(CURDIR)" MO="$(MODULE_OUTPUT_DIR)" clean 2>/dev/null || true
+	$(MAKE) -C "$(KBUILD_DIR)" M="$(CURDIR)" clean 2>/dev/null || true
 
 load: all
 	sudo dmesg -c >/dev/null


### PR DESCRIPTION
The module Makefile passed MO="$(MODULE_OUTPUT_DIR)" to kbuild to relocate build output into build/. On modern kernels this backfires: kbuild decides the kernel build tree itself needs regenerating and rewrites the kernel's own top-level Makefile (/usr/lib/modules/$(uname -r)/build/Makefile) from a .tmp_Makefile, replacing it with a short self-referential stub.

Once that happens, every out-of-tree build for that kernel breaks, DKMS included. `make` either segfaults or, once the headers directory is root-owned, dies with:

    /bin/sh: .../build/.tmp_Makefile: Permission denied
    make[3]: *** [.../build/Makefile: .../build/Makefile] Error 1

and the kernel Makefile then has to be restored from the linux-headers package.

Fix: drop MO= and let kbuild build in place with M=$(CURDIR). The module is produced at the source root and the existing copy step stages sc0710.ko into build/, so no output relocation is needed and nothing writes into the kernel build tree.