### PR TITLE
fix(dkms): harden upgrades and fix module builds on high-core systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(VERSION_HDR): version
 all: $(VERSION_HDR)
 	@mkdir -p "$(MODULE_OUTPUT_DIR)"
 	@ulimit -n 1048576 2>/dev/null || ulimit -n 65536 2>/dev/null || ulimit -n 4096 2>/dev/null || true; \
-	$(MAKE) MAKEFLAGS= -j1 -C "$(KBUILD_DIR)" M="$(CURDIR)" $(KBUILD_CC) modules
+	$(MAKE) -j1 -C "$(KBUILD_DIR)" M="$(CURDIR)" $(KBUILD_CC) modules
 	@# kbuild builds in place; stage the resulting module into build/.
 	@if [ -f "$(CURDIR)/sc0710.ko" ] && [ ! -f "$(MODULE_OUTPUT_DIR)/sc0710.ko" ]; then \
 		cp "$(CURDIR)/sc0710.ko" "$(MODULE_OUTPUT_DIR)/sc0710.ko"; \

--- a/scripts/sc0710-dkms-make.sh
+++ b/scripts/sc0710-dkms-make.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # DKMS build wrapper for sc0710.
 #
-# DKMS always rewrites "make ..." into "make -j$(nproc) KERNELRELEASE=... ...",
+# DKMS rewrites MAKE[0]="make ..." into "make -j$(nproc) KERNELRELEASE=...",
 # which can hit EMFILE in the kernel tree on high-core systems. Using a script
 # as MAKE[0] bypasses that rewrite. We also raise the open-file limit because
 # some distros give sudo/dkms a very low ulimit.
@@ -9,11 +9,15 @@ set -euo pipefail
 
 kernelver="$1"
 shift || true
-while [[ $# -gt 0 && "$1" == *"="* ]]; do
-    shift
-done
 
 ulimit -n 1048576 2>/dev/null || ulimit -n 65536 2>/dev/null || ulimit -n 4096 2>/dev/null || true
-export MAKEFLAGS=
 
-exec make -j1 KVERSION="$kernelver" KERNELRELEASE="$kernelver"
+# Older sc0710 builds used MO= and could leave bogus cmd files in the kernel
+# headers tree; remove them so kbuild does not try to "compile" Makefile.build.
+for kdir in "/lib/modules/${kernelver}/build" "/usr/lib/modules/${kernelver}/build"; do
+    [[ -d "${kdir}/scripts" ]] || continue
+    rm -f "${kdir}/scripts/Makefile.build.mod" \
+          "${kdir}/scripts/.Makefile.build.mod.cmd"
+done
+
+exec make -j1 KVERSION="$kernelver" KERNELRELEASE="$kernelver" "$@"


### PR DESCRIPTION
DKMS upgrades could fail when old sc0710 registrations or orphaned .ko files blocked installs, and module builds failed on high-core distros (EMFILE) or left the kernel headers tree in a bad state (m2c / Makefile.build.mod errors).

Add shared DKMS helpers and use them across packaging, sc0710-cli, and the curl installer: version normalization, full cleanup before install/remove, and force-install fallbacks. Extend AUR hooks (pre/post install, pacman hook 72) to scrub stale modules and ensure installation completes.

Fix DKMS builds by routing MAKE[0] through sc0710-dkms-make.sh so DKMS cannot inject -j$(nproc), raising ulimit before kbuild, capping the kbuild submake to -j1, and removing MAKEFLAGS= handling that broke kbuild. The wrapper also cleans bogus Makefile.build.mod artifacts left by older MO= builds.

Harden sc0710-cli --remove/--update with sc0710_dkms_run_cleanup() so a missing or empty DKMS lib path no longer aborts uninstall.