### PR TITLE
fix: support pre-6.16 sysfs callbacks

### DIFF
--- a/lib/sc0710-core.c
+++ b/lib/sc0710-core.c
@@ -29,10 +29,18 @@
 #include <linux/sysfs.h>
 #include "sc0710.h"
 
+/* bin_attribute callbacks became const-qualified in Linux 6.16. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+#define SC0710_BIN_ATTR_CONST const
+#else
+#define SC0710_BIN_ATTR_CONST
+#endif
+
 /* Binary sysfs write of the 1024-byte HDR→SDR tonemap blob (MK.2 MCU fn 0x63).
  * Empirically on/off patterns; path: .../sc0710/<bdf>/hdr_tonemap */
 static ssize_t hdr_tonemap_write(struct file *filp, struct kobject *kobj,
-	const struct bin_attribute *attr, char *buf, loff_t off, size_t count)
+	SC0710_BIN_ATTR_CONST struct bin_attribute *attr, char *buf, loff_t off,
+	size_t count)
 {
 	struct device *device = kobj_to_dev(kobj);
 	struct pci_dev *pdev = to_pci_dev(device);
@@ -49,6 +57,7 @@ static ssize_t hdr_tonemap_write(struct file *filp, struct kobject *kobj,
 }
 
 static BIN_ATTR_WO(hdr_tonemap, 1024);
+#undef SC0710_BIN_ATTR_CONST
 
 static ssize_t color_deep_show(struct device *device,
 	struct device_attribute *attr, char *buf)


### PR DESCRIPTION
## Summary

- use the mutable `struct bin_attribute *` callback signature required by Linux 6.12–6.15
- retain the const-qualified signature introduced in Linux 6.16
- restore builds across the repository's advertised Linux 6.12–7.0+ range

## Root cause

`hdr_tonemap_write()` currently uses `const struct bin_attribute *` unconditionally. Linux 6.12–6.15 define `struct bin_attribute.write` with a mutable attribute pointer, so `BIN_ATTR_WO(hdr_tonemap, ...)` fails with `-Wincompatible-pointer-types`. Linux 6.16 and newer require the const-qualified callback instead.

## Verification

- reproduced the build failure on Debian 13, kernel `6.12.96+deb13-amd64`
- rebuilt the complete module successfully after the compatibility guard
- `git diff --check` passed
- DKMS built, Secure Boot signed, installed, and loaded the module
- confirmed the 4K60 Pro MK.2 bound to `sc0710` and exposed `/dev/video2`
- captured 240 frames from a 1080p60 signal in 4.009 seconds (59.86 effective fps)
- checked upstream Linux headers: v6.15 uses the mutable callback; v6.16 and v7.0 use the const-qualified callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)
